### PR TITLE
fix: add /v2 module path suffix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,20 @@
 # GO Ansible
 
 [![license](https://img.shields.io/github/license/mashape/apistatus.svg?style=popout-square)](LICENSE)
-[![GitHub go.mod Go version](https://img.shields.io/github/go-mod/go-version/arillso/go.ansible?style=popout-square)](https://pkg.go.dev/github.com/arillso/go.ansible?tab=doc)
+[![GitHub go.mod Go version](https://img.shields.io/github/go-mod/go-version/arillso/go.ansible?style=popout-square)](https://pkg.go.dev/github.com/arillso/go.ansible/v2?tab=doc)
 [![GitHub release](https://img.shields.io/github/v/release/arillso/go.ansible?style=popout-square)](https://github.com/arillso/go.ansible/releases)
-[![Go Report Card](https://goreportcard.com/badge/github.com/arillso/go.ansible)](https://goreportcard.com/report/github.com/arillso/go.ansible)
+[![Go Report Card](https://goreportcard.com/badge/github.com/arillso/go.ansible/v2)](https://goreportcard.com/report/github.com/arillso/go.ansible/v2)
 
 A Go module for programmatically executing Ansible playbooks with support for Galaxy integration, temporary file management, and flexible configuration.
 
-**Documentation:** https://pkg.go.dev/github.com/arillso/go.ansible
+**Documentation:** https://pkg.go.dev/github.com/arillso/go.ansible/v2
 
 ## Quick Start
 
 Install the module:
 
 ```bash
-go get github.com/arillso/go.ansible
+go get github.com/arillso/go.ansible/v2
 ```
 
 Basic usage:
@@ -25,7 +25,7 @@ package main
 import (
     "context"
     "log"
-    "github.com/arillso/go.ansible"
+    "github.com/arillso/go.ansible/v2"
 )
 
 func main() {

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ package main
 import (
     "context"
     "log"
-    "github.com/arillso/go.ansible/v2"
+    "github.com/arillso/go.ansible/v2" // package name is "ansible"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/arillso/go.ansible
+module github.com/arillso/go.ansible/v2
 
 go 1.26.1


### PR DESCRIPTION
## Summary

- Add `/v2` suffix to `go.mod` module path (`github.com/arillso/go.ansible/v2`)
- Update all import paths and badge URLs in README.md

Go modules with major version >= 2 require the version suffix in the module path per the [Go module major version suffix convention](https://go.dev/ref/mod#major-version-suffixes).

## Test plan

- [ ] `go build ./...` succeeds
- [ ] `go test ./...` passes
- [ ] Consumers can `go get github.com/arillso/go.ansible/v2@v2.0.0`