### PR TITLE
docs: add runnable examples (Vault, Galaxy, context, extra vars)

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,9 @@ pb := ansible.NewPlaybook()
 pb.Config.Playbooks = []string{"site.yml"}
 pb.Config.Inventories = []string{"production,"}
 pb.Config.VaultPassword = "s3cr3t"
-err := pb.Exec(context.Background())
+if err := pb.Exec(context.Background()); err != nil {
+    log.Fatal(err)
+}
 ```
 
 ### Galaxy requirements
@@ -68,7 +70,9 @@ pb := ansible.NewPlaybook()
 pb.Config.GalaxyFile = "requirements.yml"
 pb.Config.Playbooks = []string{"site.yml"}
 pb.Config.Inventories = []string{"localhost,"}
-err := pb.Exec(context.Background())
+if err := pb.Exec(context.Background()); err != nil {
+    log.Fatal(err)
+}
 ```
 
 ### Extra vars, limit and tags
@@ -80,7 +84,9 @@ pb.Config.Inventories = []string{"production,"}
 pb.Config.ExtraVars = []string{"env=staging", "version=1.2.3"}
 pb.Config.Limit = "web"
 pb.Config.Tags = "deploy"
-err := pb.Exec(context.Background())
+if err := pb.Exec(context.Background()); err != nil {
+    log.Fatal(err)
+}
 ```
 
 ### Cancellation with context
@@ -94,7 +100,9 @@ defer cancel()
 pb := ansible.NewPlaybook()
 pb.Config.Playbooks = []string{"site.yml"}
 pb.Config.Inventories = []string{"localhost,"}
-err := pb.Exec(ctx) // returns a context error when cancelled
+if err := pb.Exec(ctx); err != nil { // returns a context error when cancelled
+    log.Fatal(err)
+}
 ```
 
 Preview the generated command without running Ansible via

--- a/README.md
+++ b/README.md
@@ -39,6 +39,67 @@ func main() {
 }
 ```
 
+## Examples
+
+Runnable examples live in [`example_test.go`](example_test.go) and on
+[pkg.go.dev](https://pkg.go.dev/github.com/arillso/go.ansible/v2#pkg-examples).
+A few common setups:
+
+### Vault password
+
+The password is written to a temporary file and passed via
+`--vault-password-file`. Set `Config.TempDir` to a tmpfs mount in
+security-critical environments so secrets never touch persistent disk.
+
+```go
+pb := ansible.NewPlaybook()
+pb.Config.Playbooks = []string{"site.yml"}
+pb.Config.Inventories = []string{"production,"}
+pb.Config.VaultPassword = "s3cr3t"
+err := pb.Exec(context.Background())
+```
+
+### Galaxy requirements
+
+Roles and collections from a requirements file are installed before the run.
+
+```go
+pb := ansible.NewPlaybook()
+pb.Config.GalaxyFile = "requirements.yml"
+pb.Config.Playbooks = []string{"site.yml"}
+pb.Config.Inventories = []string{"localhost,"}
+err := pb.Exec(context.Background())
+```
+
+### Extra vars, limit and tags
+
+```go
+pb := ansible.NewPlaybook()
+pb.Config.Playbooks = []string{"site.yml"}
+pb.Config.Inventories = []string{"production,"}
+pb.Config.ExtraVars = []string{"env=staging", "version=1.2.3"}
+pb.Config.Limit = "web"
+pb.Config.Tags = "deploy"
+err := pb.Exec(context.Background())
+```
+
+### Cancellation with context
+
+Cancelling the context terminates the underlying `ansible-playbook` process —
+useful for honouring `SIGINT` or an overall deadline.
+
+```go
+ctx, cancel := context.WithCancel(context.Background())
+defer cancel()
+pb := ansible.NewPlaybook()
+pb.Config.Playbooks = []string{"site.yml"}
+pb.Config.Inventories = []string{"localhost,"}
+err := pb.Exec(ctx) // returns a context error when cancelled
+```
+
+Preview the generated command without running Ansible via
+`pb.CommandStrings(ctx)`.
+
 ## Features
 
 - Automated playbook resolution with glob pattern support

--- a/example_test.go
+++ b/example_test.go
@@ -1,0 +1,92 @@
+// Runnable examples for the ansible package. These compile and run as part of
+// `go test`, appear on pkg.go.dev, and use CommandStrings so they preview the
+// generated command lines without needing an ansible binary installed.
+package ansible_test
+
+import (
+	"context"
+	"fmt"
+
+	ansible "github.com/arillso/go.ansible/v2"
+)
+
+// ExampleNewPlaybook shows the minimal setup: run a playbook against an
+// inline inventory.
+func ExampleNewPlaybook() {
+	pb := ansible.NewPlaybook()
+	pb.Config.Playbooks = []string{"arillso.example.site"}
+	pb.Config.Inventories = []string{"localhost,"}
+
+	// Exec(ctx) would run it; CommandStrings previews the command instead.
+	cmds, err := pb.CommandStrings(context.Background())
+	if err != nil {
+		fmt.Println("error:", err)
+		return
+	}
+	fmt.Println(cmds[0])
+	// Output: ansible-playbook --inventory localhost, --forks 5 arillso.example.site
+}
+
+// ExamplePlaybook_vault shows running a playbook with a Vault password. The
+// password is written to a temporary file and passed via --vault-password-file;
+// set TempDir to a tmpfs in security-critical environments.
+func ExamplePlaybook_vault() {
+	pb := ansible.NewPlaybook()
+	pb.Config.Playbooks = []string{"arillso.example.site"}
+	pb.Config.Inventories = []string{"production,"}
+	pb.Config.VaultPassword = "s3cr3t"
+
+	if err := pb.Exec(context.Background()); err != nil {
+		// handle the error; omitted here for brevity
+		_ = err
+	}
+}
+
+// ExamplePlaybook_galaxy shows installing roles and collections from a
+// requirements file before the playbook run.
+func ExamplePlaybook_galaxy() {
+	pb := ansible.NewPlaybook()
+	pb.Config.GalaxyFile = "requirements.yml"
+	pb.Config.Playbooks = []string{"arillso.example.site"}
+	pb.Config.Inventories = []string{"localhost,"}
+
+	if err := pb.Exec(context.Background()); err != nil {
+		_ = err
+	}
+}
+
+// ExamplePlaybook_extraVars shows passing extra variables and limiting the run
+// to a subset of hosts and tags.
+func ExamplePlaybook_extraVars() {
+	pb := ansible.NewPlaybook()
+	pb.Config.Playbooks = []string{"arillso.example.site"}
+	pb.Config.Inventories = []string{"production,"}
+	pb.Config.ExtraVars = []string{"env=staging", "version=1.2.3"}
+	pb.Config.Limit = "web"
+	pb.Config.Tags = "deploy"
+
+	cmds, err := pb.CommandStrings(context.Background())
+	if err != nil {
+		fmt.Println("error:", err)
+		return
+	}
+	fmt.Println(cmds[0])
+	// Output: ansible-playbook --inventory production, --forks 5 --limit web --tags deploy --extra-vars env=staging --extra-vars version=1.2.3 arillso.example.site
+}
+
+// ExamplePlaybook_context shows cancelling a run with a context. Cancelling the
+// context terminates the underlying ansible-playbook process.
+func ExamplePlaybook_context() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	pb := ansible.NewPlaybook()
+	pb.Config.Playbooks = []string{"arillso.example.site"}
+	pb.Config.Inventories = []string{"localhost,"}
+
+	// In real code, cancel() from another goroutine (e.g. on SIGINT) to stop
+	// the run; Exec returns a context error when cancelled.
+	if err := pb.Exec(ctx); err != nil {
+		_ = err
+	}
+}


### PR DESCRIPTION
## Summary

Closes two Notion tickets: **Reale Code-Beispiele (Vault, Galaxy, Context) ins README** and **examples/-Paket mit example_test.go**.

- **`example_test.go`**: runnable `Example` functions — `ExampleNewPlaybook`, `ExamplePlaybook_vault`, `_galaxy`, `_extraVars`, `_context`. They compile and run under `go test`, appear on pkg.go.dev, and use `CommandStrings` with `// Output:` assertions where the output is deterministic (no ansible binary needed). The `Exec`-based ones are compile-checked.
- **README**: an Examples section with Vault, Galaxy, extra-vars/limit/tags, and context-cancellation snippets, linking to `example_test.go` and pkg.go.dev.

The `// Output:` assertions were verified against the real `CommandStrings` output (e.g. `--inventory`, `--forks 5`), not guessed.

## Test plan

- [x] `gofmt`, `go vet` clean
- [x] `go test ./...` passes (Example Output assertions match real output)